### PR TITLE
Remove unused dependency

### DIFF
--- a/zqutils/Cargo.toml
+++ b/zqutils/Cargo.toml
@@ -36,8 +36,6 @@ semver = "1.0.21"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"
-sqlx = "0.7.3"
-sqlx-postgres = "0.7.3"
 sysctl = "0.5.5"
 sysinfo = "0.30.5"
 tokio = { version = "1.32.0", features = ["full"] }


### PR DESCRIPTION
Due to a cargo bug, this was causing issues with adding rusqlite to ZQ2. See https://github.com/launchbadge/sqlx/issues/3211 - Cargo would detect a spurious version conflict in the sqlite version to bundle.
However sqlx appears completely unused in zqutils so removing the dependency entirely is an easy fix. (Otherwise, careful selection of features would be necessary to avoid triggering the bug.)